### PR TITLE
added routes to check all unapproved pantries and to approve of pantries

### DIFF
--- a/apps/backend/src/pantries/pantries.controller.ts
+++ b/apps/backend/src/pantries/pantries.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe, Post } from '@nestjs/common';
 import { Pantry } from './pantry.entity';
 import { PantriesService } from './pantries.service';
 
@@ -6,10 +6,22 @@ import { PantriesService } from './pantries.service';
 export class PantriesController {
   constructor(private pantriesService: PantriesService) {}
 
+  @Get('/nonApproved')
+  async getNotApprovedPantries(): Promise<Pantry[]> {
+    return this.pantriesService.getNonApprovedPantries();
+  }
+
   @Get('/:pantryId')
   async getPantry(
     @Param('pantryId', ParseIntPipe) pantryId: number,
   ): Promise<Pantry> {
     return this.pantriesService.findOne(pantryId);
+  }
+
+  @Post('/approve/:pantryId')
+  async approvePantry(
+    @Param('pantryId', ParseIntPipe) pantryId: number,
+  ): Promise<void> {
+    return this.pantriesService.approve(pantryId);
   }
 }

--- a/apps/backend/src/pantries/pantries.service.ts
+++ b/apps/backend/src/pantries/pantries.service.ts
@@ -12,7 +12,22 @@ export class PantriesService {
     if (!id) {
       return null;
     }
-
     return this.repo.findOneBy({ id });
+  }
+
+  approve(id: number) {
+    this.repo
+      .createQueryBuilder()
+      .update(Pantry)
+      .set({ approved: true })
+      .where('id = :id', { id: id })
+      .execute();
+  }
+  getNonApprovedPantries() {
+    return this.repo.find({
+      where: {
+        approved: false,
+      },
+    });
   }
 }


### PR DESCRIPTION
### ℹ️ Issue

Closes https://trello.com/c/21bAJGQk/11-create-an-api-route-allowing-users-to-approve-deny-pantrys-request-to-create-a-new-account

### 📝 Description
Added an api endpoint that retrieves pantries waiting for approval.
Added an api endpoint that sets the pantry approved status to true. 

### ✔️ Verification
Tested using swagger, both endpoints are able to manipulate dummy data inputted via pgadmin.

### 🏕️ (Optional) Future Work / Notes

I dont think there is proper authentication on either endpoints. Will need to consult Sam about auth.
