### PR TITLE
Ot.confirm donations

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { AppService } from './app.service';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { DonationsModule } from './donations/donations.module';
 import typeorm from './config/typeorm';
 
 @Module({
@@ -22,6 +23,7 @@ import typeorm from './config/typeorm';
     }),
     UsersModule,
     AuthModule,
+    DonationsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/backend/src/donations/donation.entity.ts
+++ b/apps/backend/src/donations/donation.entity.ts
@@ -1,0 +1,27 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { DonationStatus } from './types';
+
+@Entity()
+export class Donation {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'text', array: true }) //FIX
+  restrictions: string[];
+
+  @Column({ type: 'timestamp' })
+  due_date: Date;
+
+  @Column({ type: 'int' })
+  pantry_id: number;
+
+  //@Column({ type: 'varchar', length: 50 })
+  @Column({ type: 'enum', enum: DonationStatus })
+  status: string;
+
+  @Column({ type: 'text', nullable: true })
+  feedback: string;
+
+  @Column({ type: 'json' })
+  contents: JSON;
+}

--- a/apps/backend/src/donations/donation.entity.ts
+++ b/apps/backend/src/donations/donation.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, PrimaryGeneratedColumn, Timestamp } from 'typeorm';
 import { DonationStatus } from './types';
 
 @Entity()
@@ -10,7 +10,7 @@ export class Donation {
   restrictions: string[];
 
   @Column({ type: 'timestamp' })
-  due_date: Date;
+  due_date: Timestamp;
 
   @Column({ type: 'int' })
   pantry_id: number;

--- a/apps/backend/src/donations/donations.controller.ts
+++ b/apps/backend/src/donations/donations.controller.ts
@@ -1,0 +1,54 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  UseGuards,
+} from '@nestjs/common';
+import { DonationsService } from './donations.service';
+import { CreateDonationDto } from './dto/create-donation.dto';
+import { UpdateDonationDto } from './dto/update-donation.dto';
+import { FilterDonationsDto } from './dto/filter-donations.dto';
+import { AuthGuard } from '@nestjs/passport';
+
+@Controller('donations')
+export class DonationsController {
+  constructor(private readonly donationsService: DonationsService) {}
+
+  @Post()
+  create(@Body() createDonationDto: CreateDonationDto) {
+    return this.donationsService.create(createDonationDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.donationsService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.donationsService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id') id: string,
+    @Body() updateDonationDto: UpdateDonationDto,
+  ) {
+    return this.donationsService.update(+id, updateDonationDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.donationsService.remove(+id);
+  }
+
+  @UseGuards(AuthGuard('jwt'))
+  @Get('/orders')
+  filter(@Body() filterDonationsDto: FilterDonationsDto) {
+    return this.donationsService.filter(filterDonationsDto);
+  }
+}

--- a/apps/backend/src/donations/donations.controller.ts
+++ b/apps/backend/src/donations/donations.controller.ts
@@ -21,7 +21,6 @@ export class DonationsController {
 
   @Get('orders')
   filter(@Body() filterDonationsDto: FilterDonationsDto) {
-    console.log('HERE');
     return this.donationsService.filter(filterDonationsDto);
   }
 

--- a/apps/backend/src/donations/donations.controller.ts
+++ b/apps/backend/src/donations/donations.controller.ts
@@ -24,6 +24,11 @@ export class DonationsController {
     return this.donationsService.filter(filterDonationsDto);
   }
 
+  @Patch('confirm/:id')
+  confirm(@Param('id') id: string) {
+    return this.donationsService.confirmReceived(+id);
+  }
+
   @Post()
   create(@Body() createDonationDto: CreateDonationDto) {
     return this.donationsService.create(createDonationDto);

--- a/apps/backend/src/donations/donations.controller.ts
+++ b/apps/backend/src/donations/donations.controller.ts
@@ -13,10 +13,17 @@ import { CreateDonationDto } from './dto/create-donation.dto';
 import { UpdateDonationDto } from './dto/update-donation.dto';
 import { FilterDonationsDto } from './dto/filter-donations.dto';
 import { AuthGuard } from '@nestjs/passport';
+import { Logger } from '@nestjs/common';
 
 @Controller('donations')
 export class DonationsController {
   constructor(private readonly donationsService: DonationsService) {}
+
+  @Get('orders')
+  filter(@Body() filterDonationsDto: FilterDonationsDto) {
+    console.log('HERE');
+    return this.donationsService.filter(filterDonationsDto);
+  }
 
   @Post()
   create(@Body() createDonationDto: CreateDonationDto) {
@@ -44,11 +51,5 @@ export class DonationsController {
   @Delete(':id')
   remove(@Param('id') id: string) {
     return this.donationsService.remove(+id);
-  }
-
-  @UseGuards(AuthGuard('jwt'))
-  @Get('/orders')
-  filter(@Body() filterDonationsDto: FilterDonationsDto) {
-    return this.donationsService.filter(filterDonationsDto);
   }
 }

--- a/apps/backend/src/donations/donations.module.ts
+++ b/apps/backend/src/donations/donations.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { DonationsService } from './donations.service';
+import { DonationsController } from './donations.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Donation } from './donation.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Donation])],
+  controllers: [DonationsController],
+  providers: [DonationsService],
+})
+export class DonationsModule {}

--- a/apps/backend/src/donations/donations.service.ts
+++ b/apps/backend/src/donations/donations.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+import { CreateDonationDto } from './dto/create-donation.dto';
+import { UpdateDonationDto } from './dto/update-donation.dto';
+import { FilterDonationsDto } from './dto/filter-donations.dto';
+import { Donation } from './donation.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Between, In } from 'typeorm';
+
+@Injectable()
+export class DonationsService {
+  constructor(@InjectRepository(Donation) private repo: Repository<Donation>) {}
+
+  create(createDonationDto: CreateDonationDto) {
+    return 'This action adds a new donation';
+  }
+
+  findAll() {
+    return `This action returns all donations`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} donation`;
+  }
+
+  update(id: number, updateDonationDto: UpdateDonationDto) {
+    return `This action updates a #${id} donation`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} donation`;
+  }
+
+  filter(filterDonationsDto: FilterDonationsDto) {
+    return this.repo.find({
+      where: {
+        pantry_id: In(filterDonationsDto.pantry_ids),
+        status: filterDonationsDto.status,
+        due_date: Between(
+          filterDonationsDto.due_date_start,
+          filterDonationsDto.due_date_end,
+        ),
+      },
+    });
+  }
+}

--- a/apps/backend/src/donations/donations.service.ts
+++ b/apps/backend/src/donations/donations.service.ts
@@ -30,16 +30,29 @@ export class DonationsService {
     return `This action removes a #${id} donation`;
   }
 
-  filter(filterDonationsDto: FilterDonationsDto) {
-    return this.repo.find({
-      where: {
-        pantry_id: In(filterDonationsDto.pantry_ids),
+  async filter(filterDonationsDto: FilterDonationsDto) {
+    let query = this.repo.createQueryBuilder('donation');
+    if (filterDonationsDto.pantry_ids != null) {
+      query = query.where('donation.pantry_id IN (:...ids)', {
+        ids: filterDonationsDto.pantry_ids,
+      });
+    }
+    if (filterDonationsDto.status != null) {
+      query = query.andWhere('donation.status = :status', {
         status: filterDonationsDto.status,
-        due_date: Between(
-          filterDonationsDto.due_date_start,
-          filterDonationsDto.due_date_end,
-        ),
-      },
-    });
+      });
+    }
+    if (filterDonationsDto.due_date_start != null) {
+      query = query.andWhere('donation.due_date >= :start', {
+        start: filterDonationsDto.due_date_start,
+      });
+    }
+    if (filterDonationsDto.due_date_end != null) {
+      query = query.andWhere('donation.due_date <= :end', {
+        end: filterDonationsDto.due_date_end,
+      });
+    }
+    const donations = await query.getMany();
+    return donations;
   }
 }

--- a/apps/backend/src/donations/donations.service.ts
+++ b/apps/backend/src/donations/donations.service.ts
@@ -30,6 +30,16 @@ export class DonationsService {
     return `This action removes a #${id} donation`;
   }
 
+  async confirmReceived(id: number) {
+    const query = this.repo.createQueryBuilder();
+    const res = await query
+      .update(Donation)
+      .set({ status: 'RECEIVED' })
+      .where('id = :id', { id: id })
+      .execute();
+    return res;
+  }
+
   async filter(filterDonationsDto: FilterDonationsDto) {
     let query = this.repo.createQueryBuilder('donation');
     if (filterDonationsDto.pantry_ids != null) {

--- a/apps/backend/src/donations/dto/create-donation.dto.ts
+++ b/apps/backend/src/donations/dto/create-donation.dto.ts
@@ -1,0 +1,1 @@
+export class CreateDonationDto {}

--- a/apps/backend/src/donations/dto/filter-donations.dto.ts
+++ b/apps/backend/src/donations/dto/filter-donations.dto.ts
@@ -1,12 +1,5 @@
-import {
-  IsDate,
-  IsDateString,
-  IsEnum,
-  IsInt,
-  IsOptional,
-} from 'class-validator';
+import { IsDateString, IsEnum, IsInt, IsOptional } from 'class-validator';
 import { DonationStatus } from '../types';
-import { Timestamp } from 'typeorm';
 
 export class FilterDonationsDto {
   @IsDateString()

--- a/apps/backend/src/donations/dto/filter-donations.dto.ts
+++ b/apps/backend/src/donations/dto/filter-donations.dto.ts
@@ -1,17 +1,27 @@
-import { IsDate, IsDateString, IsEnum, IsInt } from 'class-validator';
+import {
+  IsDate,
+  IsDateString,
+  IsEnum,
+  IsInt,
+  IsOptional,
+} from 'class-validator';
 import { DonationStatus } from '../types';
 import { Timestamp } from 'typeorm';
 
 export class FilterDonationsDto {
   @IsDateString()
+  @IsOptional()
   due_date_start: Date;
 
   @IsDateString()
+  @IsOptional()
   due_date_end: Date;
 
   @IsInt({ each: true })
+  @IsOptional()
   pantry_ids: number[];
 
   @IsEnum(DonationStatus)
+  @IsOptional()
   status: string;
 }

--- a/apps/backend/src/donations/dto/filter-donations.dto.ts
+++ b/apps/backend/src/donations/dto/filter-donations.dto.ts
@@ -1,11 +1,12 @@
-import { IsDate, IsEnum, IsInt } from 'class-validator';
+import { IsDate, IsDateString, IsEnum, IsInt } from 'class-validator';
 import { DonationStatus } from '../types';
+import { Timestamp } from 'typeorm';
 
 export class FilterDonationsDto {
-  @IsDate()
+  @IsDateString()
   due_date_start: Date;
 
-  @IsDate()
+  @IsDateString()
   due_date_end: Date;
 
   @IsInt({ each: true })

--- a/apps/backend/src/donations/dto/filter-donations.dto.ts
+++ b/apps/backend/src/donations/dto/filter-donations.dto.ts
@@ -1,0 +1,16 @@
+import { IsDate, IsEnum, IsInt } from 'class-validator';
+import { DonationStatus } from '../types';
+
+export class FilterDonationsDto {
+  @IsDate()
+  due_date_start: Date;
+
+  @IsDate()
+  due_date_end: Date;
+
+  @IsInt({ each: true })
+  pantry_ids: number[];
+
+  @IsEnum(DonationStatus)
+  status: string;
+}

--- a/apps/backend/src/donations/dto/update-donation.dto.ts
+++ b/apps/backend/src/donations/dto/update-donation.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateDonationDto } from './create-donation.dto';
+
+export class UpdateDonationDto extends PartialType(CreateDonationDto) {}

--- a/apps/backend/src/donations/types.ts
+++ b/apps/backend/src/donations/types.ts
@@ -1,0 +1,4 @@
+export enum DonationStatus {
+  FULFILLED = 'FULFILLED',
+  UNFULFILLED = 'UNFULFILLED',
+}


### PR DESCRIPTION
📝 Description
Adds the PATCH endpoint /api/donations/confirm/:id to replace the status of the donation with the given ID to "RECEIVED".
Returns in the body:
{
"generatedMaps": [],
"raw": [],
"affected": 1
}

Doesn't fail if the given id doesn't exist, but affected will be 0.

✔️ Verification
Called with postman PATCH http://localhost:3000/api/donations/confirm/6, verified changes in pgadmin local db.
Screenshot 2024-11-17 at 7 50 05 PM

Provide screenshots of any new components, styling changes, or pages.

🏕️ (Optional) Future Work / Notes
Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!