### PR TITLE
disabled submitting new request button until all deliveries are confi…

### DIFF
--- a/apps/frontend/src/components/forms/requestFormModalButton.tsx
+++ b/apps/frontend/src/components/forms/requestFormModalButton.tsx
@@ -45,11 +45,13 @@ const getAllergens = () => {
 interface FoodRequestFormModalProps {
   previousRequest?: FoodRequest;
   buttonText: string;
+  disabled: boolean;
 }
 
 const FoodRequestFormModal: React.FC<FoodRequestFormModalProps> = ({
   previousRequest,
   buttonText,
+  disabled,
 }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
 
@@ -74,7 +76,9 @@ const FoodRequestFormModal: React.FC<FoodRequestFormModalProps> = ({
 
   return (
     <>
-      <Button onClick={onOpen}>{buttonText}</Button>
+      <Button onClick={onOpen} disabled={disabled}>
+        {buttonText}
+      </Button>
       <Modal isOpen={isOpen} size={'xl'} onClose={onClose}>
         <ModalOverlay />
         <ModalContent maxW="49em">

--- a/apps/frontend/src/components/forms/requestFormModalButton.tsx
+++ b/apps/frontend/src/components/forms/requestFormModalButton.tsx
@@ -76,7 +76,7 @@ const FoodRequestFormModal: React.FC<FoodRequestFormModalProps> = ({
 
   return (
     <>
-      <Button onClick={onOpen} disabled={disabled}>
+      <Button onClick={onOpen} isDisabled={disabled}>
         {buttonText}
       </Button>
       <Modal isOpen={isOpen} size={'xl'} onClose={onClose}>

--- a/apps/frontend/src/containers/FormRequests.tsx
+++ b/apps/frontend/src/containers/FormRequests.tsx
@@ -76,9 +76,7 @@ const FormRequests: React.FC = () => {
   };
 
   useEffect(() => {
-    setAllConfirmed(
-      requests.every((request) => request.status === 'fulfilled'),
-    );
+    setAllConfirmed(requests.every((request) => request.dateReceived !== null));
   }, [requests]);
 
   return (

--- a/apps/frontend/src/containers/FormRequests.tsx
+++ b/apps/frontend/src/containers/FormRequests.tsx
@@ -76,7 +76,9 @@ const FormRequests: React.FC = () => {
   };
 
   useEffect(() => {
-    setAllConfirmed(requests.every((request) => request.dateReceived !== null));
+    setAllConfirmed(
+      requests.every((request) => request.status === 'fulfilled'),
+    );
   }, [requests]);
 
   return (

--- a/apps/frontend/src/containers/FormRequests.tsx
+++ b/apps/frontend/src/containers/FormRequests.tsx
@@ -21,6 +21,7 @@ const FormRequests: React.FC = () => {
     FoodRequest | undefined
   >(undefined);
   const { pantryId } = useParams<{ pantryId: string }>();
+  const [allConfirmed, setAllConfirmed] = useState(false);
 
   const getAllPantryRequests = async (
     pantryId: number,
@@ -74,18 +75,24 @@ const FormRequests: React.FC = () => {
     return date.toLocaleDateString('en-CA');
   };
 
+  useEffect(() => {
+    setAllConfirmed(requests.every((request) => request.dateReceived !== null));
+  }, [requests]);
+
   return (
     <Center flexDirection="column" p={4}>
       <HStack spacing={200}>
         <FoodRequestFormModal
           previousRequest={undefined}
           buttonText="Submit New Request"
+          disabled={!allConfirmed}
         />
 
         {previousRequest && (
           <FoodRequestFormModal
             previousRequest={previousRequest}
             buttonText="Submit Previous Request"
+            disabled={!allConfirmed}
           />
         )}
       </HStack>


### PR DESCRIPTION

### ℹ️ Issue

Closes Issue where pantries could request food before confirming last donation

### 📝 Description

Write a short summary of what you added. Why is it important? Any member of C4C should be able to read this and understand your contribution -- not just your team members.

This is a very small change and a short ticket but I essentially added functionality so that a pantry cannot request additional food before they confirm the delivery of all previous orders. This boiled down to disabling the submit new request and submit previous request buttons in the request form page when there are still deliveries to be confirmed and re-enabling the buttons when all deliveries are confirmed. 

Briefly list the changes made to the code:
1. Added functionality to disable and re-enable the request form when appropriate

### ✔️ Verification

To verify my changes I simply added to the database some form requests where none of the requests were confirmed. I then
checked the frontend to see the disabled buttons. Finally, I confirmed the requests and checked the frontend again to see the buttons re-enabled.

Provide screenshots of any new components, styling changes, or pages. 

![image](https://github.com/user-attachments/assets/f3007612-7937-47c9-b971-d791f05d4e3d)
![image](https://github.com/user-attachments/assets/e2201d79-7d61-49e1-8df5-046c13a730b9)


### 🏕️ (Optional) Future Work / Notes

Nothing extra to note.
