### PR TITLE
[SSF-185] volunteer order management page

### DIFF
--- a/apps/backend/src/auth/ownership.decorator.ts
+++ b/apps/backend/src/auth/ownership.decorator.ts
@@ -1,4 +1,5 @@
 import { SetMetadata, Type } from '@nestjs/common';
+import { Role } from '../users/types';
 
 // Resolver function type to get the owner user ID for a given entity ID
 // Should return the user IDs of the users who are authorized to call the
@@ -20,6 +21,7 @@ export interface ServiceRegistry {
 export interface OwnershipConfig {
   idParam: string;
   resolver: OwnerIdResolver;
+  bypassRoles?: Role[];
 }
 
 export const OWNERSHIP_CHECK_KEY = 'ownership_check';

--- a/apps/backend/src/auth/ownership.guard.spec.ts
+++ b/apps/backend/src/auth/ownership.guard.spec.ts
@@ -140,4 +140,68 @@ describe('OwnershipGuard', () => {
     // If it fails to parse, it will throw ForbiddenException before even calling the resolver.
     await expect(guard.canActivate(ctx)).resolves.toBe(true);
   });
+
+  describe('OwnershipGuard bypassRoles', () => {
+    it('returns true when user role is in bypassRoles without calling resolver', async () => {
+      const resolver = jest.fn();
+      const config: OwnershipConfig = {
+        idParam: 'id',
+        resolver,
+        bypassRoles: [Role.VOLUNTEER],
+      };
+      const guard = new OwnershipGuard(makeReflector(config), makeModuleRef());
+      const ctx = makeExecutionContext(dummyUser, { id: '10' });
+      await expect(guard.canActivate(ctx)).resolves.toBe(true);
+      expect(resolver).not.toHaveBeenCalled();
+    });
+
+    it('does not bypass when user role is not in bypassRoles', async () => {
+      const pantryUser: User = { id: 55, role: Role.PANTRY } as User;
+      const config: OwnershipConfig = {
+        idParam: 'id',
+        resolver: async () => [99],
+        bypassRoles: [Role.VOLUNTEER],
+      };
+      const guard = new OwnershipGuard(makeReflector(config), makeModuleRef());
+      const ctx = makeExecutionContext(pantryUser, { id: '10' });
+      await expect(guard.canActivate(ctx)).rejects.toThrow(ForbiddenException);
+    });
+
+    it('bypasses when user role matches one of multiple bypassRoles', async () => {
+      const pantryUser: User = { id: 55, role: Role.PANTRY } as User;
+      const resolver = jest.fn();
+      const config: OwnershipConfig = {
+        idParam: 'id',
+        resolver,
+        bypassRoles: [Role.VOLUNTEER, Role.PANTRY],
+      };
+      const guard = new OwnershipGuard(makeReflector(config), makeModuleRef());
+      const ctx = makeExecutionContext(pantryUser, { id: '10' });
+      await expect(guard.canActivate(ctx)).resolves.toBe(true);
+      expect(resolver).not.toHaveBeenCalled();
+    });
+
+    it('admin bypasses regardless of bypassRoles', async () => {
+      const resolver = jest.fn();
+      const config: OwnershipConfig = {
+        idParam: 'id',
+        resolver,
+        bypassRoles: [],
+      };
+      const guard = new OwnershipGuard(makeReflector(config), makeModuleRef());
+      const ctx = makeExecutionContext(adminUser, { id: '5' });
+      await expect(guard.canActivate(ctx)).resolves.toBe(true);
+      expect(resolver).not.toHaveBeenCalled();
+    });
+
+    it('proceeds to ownership check when bypassRoles is undefined', async () => {
+      const config: OwnershipConfig = {
+        idParam: 'id',
+        resolver: async () => [dummyUser.id],
+      };
+      const guard = new OwnershipGuard(makeReflector(config), makeModuleRef());
+      const ctx = makeExecutionContext(dummyUser, { id: '10' });
+      await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    });
+  });
 });

--- a/apps/backend/src/auth/ownership.guard.ts
+++ b/apps/backend/src/auth/ownership.guard.ts
@@ -14,6 +14,7 @@ import {
   ServiceRegistry,
 } from './ownership.decorator';
 import { User } from '../users/users.entity';
+import { Role } from '../users/types';
 
 @Injectable()
 export class OwnershipGuard implements CanActivate {
@@ -40,6 +41,11 @@ export class OwnershipGuard implements CanActivate {
 
     // Admins bypass ownership checks
     if (user.role === 'admin') {
+      return true;
+    }
+
+    // Specified roles bypass ownership checks
+    if (config.bypassRoles?.includes(user.role as Role)) {
       return true;
     }
 
@@ -87,7 +93,7 @@ export class OwnershipGuard implements CanActivate {
           const service = moduleRef.get(serviceClass, { strict: false });
           cache.set(serviceClass, service);
           return service;
-        } catch (error) {
+        } catch {
           throw new Error(`Could not resolve service: ${serviceClass.name}`);
         }
       },

--- a/apps/backend/src/orders/order.controller.ts
+++ b/apps/backend/src/orders/order.controller.ts
@@ -83,7 +83,9 @@ export class OrdersController {
         (pantry: Pantry) => [pantry.pantryUser.id],
       );
     },
+    bypassRoles: [Role.VOLUNTEER],
   })
+  @Roles(Role.VOLUNTEER, Role.PANTRY)
   @Get('/:orderId/request')
   async getRequestFromOrder(
     @Param('orderId', ParseIntPipe) orderId: number,

--- a/apps/frontend/src/api/apiClient.ts
+++ b/apps/frontend/src/api/apiClient.ts
@@ -29,6 +29,8 @@ import {
   PantryWithUser,
   Assignments,
   UpdateProfileFields,
+  VolunteerOrder,
+  VolunteerAction,
 } from 'types/types';
 
 const defaultBaseUrl =
@@ -215,6 +217,19 @@ export class ApiClient {
 
   public async getVolunteerPantries(userId: number): Promise<Pantry[]> {
     return this.get(`/api/volunteers/${userId}/pantries`) as Promise<Pantry[]>;
+  }
+
+  public async getVolunteerOrders(userId: number): Promise<VolunteerOrder[]> {
+    return this.get(`/api/volunteers/${userId}/orders`) as Promise<
+      VolunteerOrder[]
+    >;
+  }
+
+  public async completeOrderAction(
+    orderId: number,
+    action: VolunteerAction,
+  ): Promise<void> {
+    await this.patch(`/api/orders/${orderId}/complete-action`, { action });
   }
 
   public async updateUser(

--- a/apps/frontend/src/app.tsx
+++ b/apps/frontend/src/app.tsx
@@ -33,6 +33,7 @@ import ApproveFoodManufacturers from '@containers/approveFoodManufacturers';
 import FoodManufacturerApplicationDetails from '@containers/foodManufacturerApplicationDetails';
 import VolunteerRequestManagement from '@containers/volunteerRequestManagement';
 import ProfilePage from '@containers/profilePage';
+import VolunteerOrderManagement from '@containers/volunteerOrderManagement';
 
 Amplify.configure(CognitoAuthConfig);
 
@@ -235,6 +236,14 @@ const router = createBrowserRouter([
         element: (
           <ProtectedRoute>
             <VolunteerRequestManagement />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: '/volunteer-order-management',
+        element: (
+          <ProtectedRoute>
+            <VolunteerOrderManagement />
           </ProtectedRoute>
         ),
       },

--- a/apps/frontend/src/components/forms/completeRequiredActionsModal.tsx
+++ b/apps/frontend/src/components/forms/completeRequiredActionsModal.tsx
@@ -1,0 +1,181 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Button,
+  VStack,
+  CloseButton,
+  Text,
+  Flex,
+  Dialog,
+} from '@chakra-ui/react';
+import { CircleCheck } from 'lucide-react';
+import ApiClient from '@api/apiClient';
+import {
+  VolunteerOrder,
+  VolunteerAction,
+  VolunteerActionCompletion,
+} from '../../types/types';
+import { FloatingAlert } from '@components/floatingAlert';
+import { useAlert } from '../../hooks/alert';
+
+interface CompleteRequiredActionsModalProps {
+  order: VolunteerOrder;
+  isOpen: boolean;
+  onClose: () => void;
+  onActionCompleted: (orderId: number, action: VolunteerAction) => void;
+}
+
+const CompleteRequiredActionsModal: React.FC<
+  CompleteRequiredActionsModalProps
+> = ({ order, isOpen, onClose, onActionCompleted }) => {
+  const [alertState, setAlertMessage] = useAlert();
+  const [loadingAction, setLoadingAction] = useState<VolunteerAction | null>(
+    null,
+  );
+
+  const completion: VolunteerActionCompletion = order.actionCompletion ?? {
+    confirmDonationReceipt: false,
+    notifyPantry: false,
+  };
+
+  const handleComplete = async (action: VolunteerAction) => {
+    setLoadingAction(action);
+    try {
+      await ApiClient.completeOrderAction(order.orderId, action);
+      onActionCompleted(order.orderId, action);
+    } catch {
+      setAlertMessage('Error completing action. Please try again.');
+    } finally {
+      setLoadingAction(null);
+    }
+  };
+
+  const sectionTitleStyles = {
+    fontWeight: '600',
+    fontSize: '14px',
+    color: 'neutral.800',
+  };
+
+  return (
+    <Dialog.Root
+      open={isOpen}
+      size="md"
+      onOpenChange={(e: { open: boolean }) => {
+        if (!e.open) onClose();
+      }}
+      closeOnInteractOutside
+    >
+      {alertState && (
+        <FloatingAlert
+          key={alertState.id}
+          message={alertState.message}
+          status="error"
+          timeout={6000}
+        />
+      )}
+      <Dialog.Backdrop />
+      <Dialog.Positioner>
+        <Dialog.Content>
+          <Dialog.CloseTrigger asChild>
+            <CloseButton size="lg" />
+          </Dialog.CloseTrigger>
+
+          <Dialog.Header pb={0}>
+            <Dialog.Title fontSize="lg" fontWeight={600}>
+              Complete Required Action
+            </Dialog.Title>
+          </Dialog.Header>
+          <Dialog.Body pb={6}>
+            <VStack align="stretch" gap={4}>
+              <Text fontSize="sm" color="gray.dark" mt={1}>
+                Please complete the following outstanding actions for this
+                order.
+              </Text>
+              <Box>
+                <Box
+                  border="1px solid"
+                  borderColor="neutral.100"
+                  borderRadius="md"
+                  p={4}
+                >
+                  <Flex align="center" gap={2}>
+                    {completion.confirmDonationReceipt && (
+                      <CircleCheck size={18} />
+                    )}
+                    <Text {...sectionTitleStyles}>
+                      Confirm Donation Receipt
+                    </Text>
+                  </Flex>
+                  <Text textStyle="p2" color="gray.dark" mt={6}>
+                    Please contact the food pantry to confirm their donation
+                    receipt order.
+                  </Text>
+                </Box>
+                {!completion.confirmDonationReceipt && (
+                  <Flex justify="flex-end" mt={4}>
+                    <Button
+                      size="sm"
+                      bg="neutral.900"
+                      color="white"
+                      fontSize="12px"
+                      px={2}
+                      h="20px"
+                      _hover={{ bg: 'neutral.700' }}
+                      loading={
+                        loadingAction ===
+                        VolunteerAction.CONFIRM_DONATION_RECEIPT
+                      }
+                      onClick={() =>
+                        handleComplete(VolunteerAction.CONFIRM_DONATION_RECEIPT)
+                      }
+                    >
+                      Mark as Complete
+                    </Button>
+                  </Flex>
+                )}
+              </Box>
+
+              <Box>
+                <Box
+                  border="1px solid"
+                  borderColor="neutral.100"
+                  borderRadius="md"
+                  p={4}
+                >
+                  <Flex align="center" gap={2}>
+                    {completion.notifyPantry && <CircleCheck size={18} />}
+                    <Text {...sectionTitleStyles}>Notify Pantry</Text>
+                  </Flex>
+                  <Text textStyle="p2" color="gray.dark" mt={6}>
+                    Subheading Content
+                  </Text>
+                </Box>
+                {!completion.notifyPantry && (
+                  <Flex justify="flex-end" mt={4}>
+                    <Button
+                      size="sm"
+                      bg="neutral.900"
+                      color="white"
+                      fontSize="12px"
+                      px={2}
+                      h="20px"
+                      _hover={{ bg: 'neutral.700' }}
+                      loading={loadingAction === VolunteerAction.NOTIFY_PANTRY}
+                      onClick={() =>
+                        handleComplete(VolunteerAction.NOTIFY_PANTRY)
+                      }
+                    >
+                      Mark as Complete
+                    </Button>
+                  </Flex>
+                )}
+              </Box>
+            </VStack>
+          </Dialog.Body>
+        </Dialog.Content>
+      </Dialog.Positioner>
+    </Dialog.Root>
+  );
+};
+
+export default CompleteRequiredActionsModal;

--- a/apps/frontend/src/containers/homepage.tsx
+++ b/apps/frontend/src/containers/homepage.tsx
@@ -118,6 +118,13 @@ const Homepage: React.FC = () => {
                 </RouterLink>
               </Link>
             </ListItem>
+            <ListItem textAlign="center">
+              <Link asChild color="teal.500">
+                <RouterLink to="/volunteer-order-management">
+                  Order Management
+                </RouterLink>
+              </Link>
+            </ListItem>
           </List.Root>
         </Box>
 

--- a/apps/frontend/src/containers/volunteerOrderManagement.tsx
+++ b/apps/frontend/src/containers/volunteerOrderManagement.tsx
@@ -47,6 +47,7 @@ const STATUS_TITLES: Record<OrderStatus, string> = {
 
 const hasRequiredActions = (order: VolunteerOrder): boolean => {
   if (!order.actionCompletion) return false;
+  if (order.status !== OrderStatus.SHIPPED) return false;
   return (
     !order.actionCompletion.confirmDonationReceipt ||
     !order.actionCompletion.notifyPantry

--- a/apps/frontend/src/containers/volunteerOrderManagement.tsx
+++ b/apps/frontend/src/containers/volunteerOrderManagement.tsx
@@ -77,6 +77,7 @@ const VolunteerOrderManagement: React.FC = () => {
   );
 
   const [alertState, setAlertMessage] = useAlert();
+  const [currentUser, setCurrentUser] = useState<User | null>(null);
 
   type FilterState = {
     selectedPantries: string[];
@@ -119,6 +120,7 @@ const VolunteerOrderManagement: React.FC = () => {
       try {
         user = await ApiClient.getMe();
         userId = user.id;
+        setCurrentUser(user);
       } catch {
         setAlertMessage('Authentication error. Please log in and try again.');
         setIsLoading(false);
@@ -284,6 +286,7 @@ const VolunteerOrderManagement: React.FC = () => {
                 })
               }
               onOpenActionModal={setActionModalOrder}
+              currentUser={currentUser}
             />
           </Box>
         );
@@ -300,8 +303,6 @@ const VolunteerOrderManagement: React.FC = () => {
     </Box>
   );
 };
-
-// ─── Order Status Section ─────────────────────────────────────────────────────
 
 interface OrderStatusSectionProps {
   orders: VolunteerOrderWithColor[];
@@ -324,6 +325,7 @@ interface OrderStatusSectionProps {
     sortAsc: boolean;
   }) => void;
   onOpenActionModal: (order: VolunteerOrder) => void;
+  currentUser: User | null;
 }
 
 const OrderStatusSection: React.FC<OrderStatusSectionProps> = ({
@@ -339,6 +341,7 @@ const OrderStatusSection: React.FC<OrderStatusSectionProps> = ({
   filterState,
   onFilterChange,
   onOpenActionModal,
+  currentUser,
 }) => {
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [isSortOpen, setIsSortOpen] = useState(false);
@@ -767,15 +770,18 @@ const OrderStatusSection: React.FC<OrderStatusSectionProps> = ({
                       bg="#FAFAFA"
                       pr={3}
                     >
-                      {needsAction && (
-                        <Link
-                          textDecorationColor="black"
-                          variant="underline"
-                          onClick={() => onOpenActionModal(order)}
-                        >
-                          Complete Required Actions
-                        </Link>
-                      )}
+                      {order.assignee?.id === currentUser?.id &&
+                        (needsAction ? (
+                          <Link
+                            textDecorationColor="black"
+                            variant="underline"
+                            onClick={() => onOpenActionModal(order)}
+                          >
+                            Complete Required Actions
+                          </Link>
+                        ) : (
+                          'No Action Required'
+                        ))}
                     </Table.Cell>
                   </Table.Row>
                 );

--- a/apps/frontend/src/containers/volunteerOrderManagement.tsx
+++ b/apps/frontend/src/containers/volunteerOrderManagement.tsx
@@ -11,6 +11,7 @@ import {
   Checkbox,
   Input,
   Link,
+  Spinner,
 } from '@chakra-ui/react';
 import {
   ArrowDownUp,
@@ -20,7 +21,6 @@ import {
   Mail,
   CircleCheck,
   Search,
-  TriangleAlert,
 } from 'lucide-react';
 import { capitalize, formatDate, getInitials } from '@utils/utils';
 import ApiClient from '@api/apiClient';
@@ -211,7 +211,7 @@ const VolunteerOrderManagement: React.FC = () => {
     });
   };
 
-  if (isLoading) return null;
+  if (isLoading) return <Spinner />;
 
   return (
     <Box p={12}>
@@ -244,8 +244,10 @@ const VolunteerOrderManagement: React.FC = () => {
           )
           .sort((a, b) =>
             filterState.sortAsc
-              ? String(a.createdAt).localeCompare(String(b.createdAt))
-              : String(b.createdAt).localeCompare(String(a.createdAt)),
+              ? new Date(a.createdAt).getTime() -
+                new Date(b.createdAt).getTime()
+              : new Date(b.createdAt).getTime() -
+                new Date(a.createdAt).getTime(),
           );
 
         const totalFiltered = filteredOrders.length;
@@ -771,7 +773,7 @@ const OrderStatusSection: React.FC<OrderStatusSectionProps> = ({
                           variant="underline"
                           onClick={() => onOpenActionModal(order)}
                         >
-                          Completed Required Actions
+                          Complete Required Actions
                         </Link>
                       )}
                     </Table.Cell>

--- a/apps/frontend/src/containers/volunteerOrderManagement.tsx
+++ b/apps/frontend/src/containers/volunteerOrderManagement.tsx
@@ -20,31 +20,54 @@ import {
   Mail,
   CircleCheck,
   Search,
+  TriangleAlert,
 } from 'lucide-react';
 import { capitalize, formatDate, getInitials } from '@utils/utils';
 import ApiClient from '@api/apiClient';
-import { OrderStatus, OrderSummary } from '../types/types';
+import {
+  OrderStatus,
+  VolunteerOrder,
+  VolunteerAction,
+  User,
+} from '../types/types';
 import OrderDetailsModal from '@components/forms/orderDetailsModal';
+import CompleteRequiredActionsModal from '@components/forms/completeRequiredActionsModal';
 import { FloatingAlert } from '@components/floatingAlert';
 import { useAlert } from '../hooks/alert';
 
-// Extending the OrderSummary type to include assignee color for display
-type OrderWithColor = OrderSummary & { assigneeColor?: string };
+type VolunteerOrderWithColor = VolunteerOrder & { assigneeColor?: string };
 
-const AdminOrderManagement: React.FC = () => {
-  // State to hold orders grouped by status
+const ASSIGNEE_COLORS = ['yellow.ssf', 'red', 'teal.ssf', 'blue.ssf'];
+
+const STATUS_TITLES: Record<OrderStatus, string> = {
+  [OrderStatus.SHIPPED]: 'In Progress',
+  [OrderStatus.PENDING]: 'Received',
+  [OrderStatus.DELIVERED]: 'Completed',
+};
+
+const hasRequiredActions = (order: VolunteerOrder): boolean => {
+  if (!order.actionCompletion) return false;
+  return (
+    !order.actionCompletion.confirmDonationReceipt ||
+    !order.actionCompletion.notifyPantry
+  );
+};
+
+const VolunteerOrderManagement: React.FC = () => {
+  const [isLoading, setIsLoading] = useState(true);
+
   const [statusOrders, setStatusOrders] = useState<
-    Record<OrderStatus, OrderWithColor[]>
+    Record<OrderStatus, VolunteerOrderWithColor[]>
   >({
     [OrderStatus.SHIPPED]: [],
     [OrderStatus.PENDING]: [],
     [OrderStatus.DELIVERED]: [],
   });
 
-  // State to hold selected order for details modal
   const [selectedOrderId, setSelectedOrderId] = useState<number | null>(null);
+  const [actionModalOrder, setActionModalOrder] =
+    useState<VolunteerOrder | null>(null);
 
-  // State to hold current page per status
   const [currentPages, setCurrentPages] = useState<Record<OrderStatus, number>>(
     {
       [OrderStatus.SHIPPED]: 1,
@@ -55,18 +78,12 @@ const AdminOrderManagement: React.FC = () => {
 
   const [alertState, setAlertMessage] = useAlert();
 
-  // State to hold filter state per status
   type FilterState = {
     selectedPantries: string[];
     searchPantry: string;
     sortAsc: boolean;
   };
 
-  // Record to store the filter state for each status
-  // selectedPantries represents the pantries selected in the filter
-  // searchPantry is the current search input for pantry filtering
-  // sortAsc indicates whether the sorting is ascending (oldest first) or descending (newest first)
-  // We store all these here to determine what orders to display for each status
   const [filterStates, setFilterStates] = useState<
     Record<OrderStatus, FilterState>
   >({
@@ -87,7 +104,6 @@ const AdminOrderManagement: React.FC = () => {
     },
   });
 
-  // Color mapping for statuses, the first color is background, the second is color for status text
   const STATUS_COLORS = new Map<OrderStatus, [string, string]>([
     [OrderStatus.SHIPPED, ['yellow.200', 'yellow.hover']],
     [OrderStatus.PENDING, ['blue.200', 'blue.core']],
@@ -96,15 +112,23 @@ const AdminOrderManagement: React.FC = () => {
 
   const MAX_PER_STATUS = 5;
 
-  const ASSIGNEE_COLORS = ['yellow.ssf', 'red', 'teal.ssf', 'blue.ssf'];
-
   useEffect(() => {
-    // Fetch all orders on component mount and sorts them into their appropriate status lists
     const fetchOrders = async () => {
+      let user: User;
+      let userId: number;
       try {
-        const data = await ApiClient.getAllOrders();
+        user = await ApiClient.getMe();
+        userId = user.id;
+      } catch {
+        setAlertMessage('Authentication error. Please log in and try again.');
+        setIsLoading(false);
+        return;
+      }
 
-        const grouped: Record<OrderStatus, OrderWithColor[]> = {
+      try {
+        const data = await ApiClient.getVolunteerOrders(userId);
+
+        const grouped: Record<OrderStatus, VolunteerOrderWithColor[]> = {
           [OrderStatus.SHIPPED]: [],
           [OrderStatus.PENDING]: [],
           [OrderStatus.DELIVERED]: [],
@@ -112,7 +136,8 @@ const AdminOrderManagement: React.FC = () => {
 
         for (const order of data) {
           const status = order.status;
-          const orderWithColor: OrderWithColor = { ...order };
+
+          const orderWithColor: VolunteerOrderWithColor = { ...order };
 
           if (order.assignee) {
             orderWithColor.assigneeColor =
@@ -132,24 +157,61 @@ const AdminOrderManagement: React.FC = () => {
         };
         setCurrentPages(initialPages);
       } catch {
-        setAlertMessage('Error fetching orders');
+        setAlertMessage('Error fetching assigned orders');
+      } finally {
+        setIsLoading(false);
       }
     };
 
     fetchOrders();
   }, [setAlertMessage]);
 
-  // Helper to reset page for a specific status
   const resetPageForStatus = (status: OrderStatus) => {
     setCurrentPages((prev) => ({ ...prev, [status]: 1 }));
   };
 
   const handlePageChange = (status: OrderStatus, page: number) => {
-    setCurrentPages((prev) => ({
-      ...prev,
-      [status]: page,
-    }));
+    setCurrentPages((prev) => ({ ...prev, [status]: page }));
   };
+
+  // Update actionCompletion in state after a successful complete-action call
+  const handleActionCompleted = (orderId: number, action: VolunteerAction) => {
+    setStatusOrders((prev) => {
+      const updated = { ...prev };
+      for (const status of Object.values(OrderStatus)) {
+        updated[status] = updated[status].map((o) => {
+          if (o.orderId !== orderId) return o;
+          const completion = o.actionCompletion ?? {
+            confirmDonationReceipt: false,
+            notifyPantry: false,
+          };
+          return {
+            ...o,
+            actionCompletion: {
+              ...completion,
+              [action]: true,
+            },
+          };
+        });
+      }
+      return updated;
+    });
+
+    // Also update the modal order so it reflects immediately
+    setActionModalOrder((prev) => {
+      if (!prev || prev.orderId !== orderId) return prev;
+      const completion = prev.actionCompletion ?? {
+        confirmDonationReceipt: false,
+        notifyPantry: false,
+      };
+      return {
+        ...prev,
+        actionCompletion: { ...completion, [action]: true },
+      };
+    });
+  };
+
+  if (isLoading) return null;
 
   return (
     <Box p={12}>
@@ -170,24 +232,20 @@ const AdminOrderManagement: React.FC = () => {
         const allOrders = statusOrders[status] || [];
         const filterState = filterStates[status];
 
-        // Get pantry options through all orders in the status
         const pantryOptions = [
-          ...new Set(allOrders.map((o) => o.request.pantry.pantryName)),
+          ...new Set(allOrders.map((o) => o.pantryName)),
         ].sort((a, b) => a.localeCompare(b));
 
-        // Apply filters and sorting to all orders
         const filteredOrders = allOrders
           .filter(
             (o) =>
               filterState.selectedPantries.length === 0 ||
-              filterState.selectedPantries.includes(
-                o.request.pantry.pantryName,
-              ),
+              filterState.selectedPantries.includes(o.pantryName),
           )
           .sort((a, b) =>
             filterState.sortAsc
-              ? a.createdAt.localeCompare(b.createdAt)
-              : b.createdAt.localeCompare(a.createdAt),
+              ? String(a.createdAt).localeCompare(String(b.createdAt))
+              : String(b.createdAt).localeCompare(String(a.createdAt)),
           );
 
         const totalFiltered = filteredOrders.length;
@@ -211,30 +269,40 @@ const AdminOrderManagement: React.FC = () => {
               pantryOptions={pantryOptions}
               filterState={filterState}
               onFilterChange={(newState: FilterState) =>
-                // Update filter state for the specific status
                 setFilterStates((prev) => {
                   const prevSelected = prev[status]?.selectedPantries || [];
                   const prevKey = [...prevSelected].sort().join(',');
                   const newKey = [...newState.selectedPantries]
                     .sort()
                     .join(',');
-                  // Reset page if selected pantries changed
                   if (prevKey !== newKey) {
                     resetPageForStatus(status);
                   }
                   return { ...prev, [status]: newState };
                 })
               }
+              onOpenActionModal={setActionModalOrder}
             />
           </Box>
         );
       })}
+
+      {actionModalOrder && (
+        <CompleteRequiredActionsModal
+          order={actionModalOrder}
+          isOpen={true}
+          onClose={() => setActionModalOrder(null)}
+          onActionCompleted={handleActionCompleted}
+        />
+      )}
     </Box>
   );
 };
 
+// ─── Order Status Section ─────────────────────────────────────────────────────
+
 interface OrderStatusSectionProps {
-  orders: OrderWithColor[];
+  orders: VolunteerOrderWithColor[];
   status: OrderStatus;
   colors: string[];
   onOrderSelect: (orderId: number | null) => void;
@@ -253,6 +321,7 @@ interface OrderStatusSectionProps {
     searchPantry: string;
     sortAsc: boolean;
   }) => void;
+  onOpenActionModal: (order: VolunteerOrder) => void;
 }
 
 const OrderStatusSection: React.FC<OrderStatusSectionProps> = ({
@@ -267,6 +336,7 @@ const OrderStatusSection: React.FC<OrderStatusSectionProps> = ({
   pantryOptions,
   filterState,
   onFilterChange,
+  onOpenActionModal,
 }) => {
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [isSortOpen, setIsSortOpen] = useState(false);
@@ -318,7 +388,7 @@ const OrderStatusSection: React.FC<OrderStatusSectionProps> = ({
           fontWeight="semibold"
           color="neutral.700"
         >
-          {capitalize(status)}
+          {STATUS_TITLES[status]}
         </Box>
       </Box>
 
@@ -342,7 +412,8 @@ const OrderStatusSection: React.FC<OrderStatusSectionProps> = ({
             No Orders
           </Box>
           <Box color="neutral.700" fontWeight="400">
-            You have no {status.toLowerCase()} orders at this time.
+            You have no {STATUS_TITLES[status].toLowerCase()} orders at this
+            time.
           </Box>
         </Box>
       ) : (
@@ -563,7 +634,7 @@ const OrderStatusSection: React.FC<OrderStatusSectionProps> = ({
                   {...tableHeaderStyles}
                   borderRight="1px solid"
                   borderRightColor="neutral.100"
-                  width="18%"
+                  width="10%"
                 >
                   Status
                 </Table.ColumnHeader>
@@ -588,14 +659,14 @@ const OrderStatusSection: React.FC<OrderStatusSectionProps> = ({
                   {...tableHeaderStyles}
                   borderRight="1px solid"
                   borderRightColor="neutral.100"
-                  width="15%"
+                  width="20%"
                 >
                   Dates
                 </Table.ColumnHeader>
                 <Table.ColumnHeader
                   {...tableHeaderStyles}
                   textAlign="right"
-                  width="20%"
+                  width="23%"
                 >
                   Action Required
                 </Table.ColumnHeader>
@@ -603,7 +674,7 @@ const OrderStatusSection: React.FC<OrderStatusSectionProps> = ({
             </Table.Header>
             <Table.Body>
               {orders.map((order, index) => {
-                const pantry = order.request.pantry;
+                const needsAction = hasRequiredActions(order);
 
                 return (
                   <Table.Row
@@ -639,7 +710,7 @@ const OrderStatusSection: React.FC<OrderStatusSectionProps> = ({
                         py={0.5}
                         px={3}
                       >
-                        {capitalize(order.status)}
+                        {capitalize(STATUS_TITLES[status])}
                       </Box>
                     </Table.Cell>
                     <Table.Cell
@@ -648,13 +719,11 @@ const OrderStatusSection: React.FC<OrderStatusSectionProps> = ({
                       borderRightColor="neutral.100"
                     >
                       <Box
-                        direction="row"
                         display="flex"
                         alignItems="center"
                         justifyContent="center"
                       >
                         <Box
-                          key={index}
                           borderRadius="full"
                           bg={order.assigneeColor || 'gray'}
                           width="33px"
@@ -677,7 +746,7 @@ const OrderStatusSection: React.FC<OrderStatusSectionProps> = ({
                       borderRight="1px solid"
                       borderRightColor="neutral.100"
                     >
-                      {pantry.pantryName}
+                      {order.pantryName}
                     </Table.Cell>
                     <Table.Cell
                       {...tableCellStyles}
@@ -686,14 +755,26 @@ const OrderStatusSection: React.FC<OrderStatusSectionProps> = ({
                       borderRight="1px solid"
                       borderRightColor="neutral.100"
                     >
-                      {formatDate(order.createdAt)}-
-                      {order.deliveredAt && formatDate(order.deliveredAt)}
+                      {formatDate(String(order.createdAt))}
+                      {order.deliveredAt &&
+                        `–${formatDate(String(order.deliveredAt))}`}
                     </Table.Cell>
                     <Table.Cell
                       {...tableCellStyles}
-                      textAlign="left"
+                      textAlign="right"
                       bg="#FAFAFA"
-                    ></Table.Cell>
+                      pr={3}
+                    >
+                      {needsAction && (
+                        <Link
+                          textDecorationColor="black"
+                          variant="underline"
+                          onClick={() => onOpenActionModal(order)}
+                        >
+                          Completed Required Actions
+                        </Link>
+                      )}
+                    </Table.Cell>
                   </Table.Row>
                 );
               })}
@@ -771,4 +852,4 @@ const OrderStatusSection: React.FC<OrderStatusSectionProps> = ({
   );
 };
 
-export default AdminOrderManagement;
+export default VolunteerOrderManagement;

--- a/apps/frontend/src/types/types.ts
+++ b/apps/frontend/src/types/types.ts
@@ -249,6 +249,33 @@ export interface OrderDetails {
   items: OrderItemDetails[];
 }
 
+export type VolunteerOrder = {
+  orderId: number;
+  status: OrderStatus;
+  createdAt: Date;
+  shippedAt: Date | null;
+  deliveredAt: Date | null;
+  pantryName: string;
+  assignee: OrderAssignee;
+  actionCompletion?: VolunteerActionCompletion;
+};
+
+export type VolunteerActionCompletion = {
+  confirmDonationReceipt: boolean;
+  notifyPantry: boolean;
+};
+
+export enum VolunteerAction {
+  CONFIRM_DONATION_RECEIPT = 'confirmDonationReceipt',
+  NOTIFY_PANTRY = 'notifyPantry',
+}
+
+export type OrderAssignee = {
+  id: number;
+  firstName: string;
+  lastName: string;
+};
+
 export interface FoodManufacturer {
   foodManufacturerId: number;
   foodManufacturerName: string;

--- a/apps/frontend/src/types/types.ts
+++ b/apps/frontend/src/types/types.ts
@@ -252,9 +252,9 @@ export interface OrderDetails {
 export type VolunteerOrder = {
   orderId: number;
   status: OrderStatus;
-  createdAt: Date;
-  shippedAt: Date | null;
-  deliveredAt: Date | null;
+  createdAt: string;
+  shippedAt: string | null;
+  deliveredAt: string | null;
   pantryName: string;
   assignee: OrderAssignee;
   actionCompletion?: VolunteerActionCompletion;


### PR DESCRIPTION
### ℹ️ Issue

Closes [SSF-185](https://vidushimisra.atlassian.net/browse/SSF-185)

### 📝 Description

new volunteer order management page [here](http://localhost:4200/volunteer-order-management)
new complete required actions modal
added endpoints to apiclient 

### ✔️ Verification
frontend page renders w/ all information
<img width="1478" height="593" alt="Screenshot 2026-04-05 at 9 24 38 PM" src="https://github.com/user-attachments/assets/dd6beb8a-1006-470e-bd49-e9f791681734" />
modal renders w/ all information, clicking "Mark as Complete" updates db
<img width="541" height="413" alt="Screenshot 2026-04-05 at 9 25 01 PM" src="https://github.com/user-attachments/assets/24e166dd-667e-45d4-841e-b1f7cc4b6f03" />

### 🏕️ (Optional) Future Work / Notes

currently the /:orderId/requests endpoint is blocked for volunteers, but is needed to render the order details modal
- pending client decision
