### PR TITLE
fix test

### DIFF
--- a/apps/backend/src/foodManufacturers/manufacturers.service.spec.ts
+++ b/apps/backend/src/foodManufacturers/manufacturers.service.spec.ts
@@ -677,6 +677,7 @@ describe('FoodManufacturersService', () => {
       const foodManufacturerId = 1;
       const yearlyDate = new Date();
       yearlyDate.setDate(yearlyDate.getDate() + 30);
+      if (yearlyDate.getDate() > 28) yearlyDate.setDate(28);
       const threeYearlyDate = new Date();
       threeYearlyDate.setFullYear(threeYearlyDate.getFullYear() + 3);
 


### PR DESCRIPTION
### ℹ️ Issue

bug: test built a date +30 days from today (april 29) → may 29 (day > 28)

why it failed: calculateNextDonationDate clamps day > 28 to 28 before adding the year, so service returned may 28, 2027 but test expected may 29, 2027

fix: clamping is intentional, generateNextDonationDates also clamps on create, so real db data is always ≤ day 28. test was the only place feeding in an unclamped date.

fix: clamp the test date the same way the service would, so they stay in sync



### 📝 Description

Write a short summary of what you added. Why is it important? Any member of C4C should be able to read this and understand your contribution -- not just your team members.

Briefly list the changes made to the code:
1. Added support for this.
2. And removed redunant use of that.
3. Also this was included for reasons.

### ✔️ Verification

What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves.

Provide screenshots of any new components, styling changes, or pages. 

### 🏕️ (Optional) Future Work / Notes

Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!
