### PR TITLE
fix date millisecond bug

### DIFF
--- a/apps/backend/src/foodManufacturers/manufacturers.service.spec.ts
+++ b/apps/backend/src/foodManufacturers/manufacturers.service.spec.ts
@@ -576,8 +576,10 @@ describe('FoodManufacturersService', () => {
     it('returns upcoming donation reminders for food manufacturer', async () => {
       const foodManufacturerId = 1;
       const futureDate1 = new Date();
+      futureDate1.setMilliseconds(0);
       futureDate1.setDate(futureDate1.getDate() + 7);
       const futureDate2 = new Date();
+      futureDate2.setMilliseconds(0);
       futureDate2.setDate(futureDate2.getDate() + 14);
 
       // FM 1 has donations 1 and 4
@@ -611,9 +613,11 @@ describe('FoodManufacturersService', () => {
 
     it('returns next two upcoming donation reminders from same donation', async () => {
       const futureDate1 = new Date();
+      futureDate1.setMilliseconds(0);
       futureDate1.setDate(futureDate1.getDate() + 30);
       clampDay(futureDate1);
       const futureDate2 = new Date();
+      futureDate2.setMilliseconds(0);
       futureDate2.setDate(futureDate2.getDate() + 60);
       clampDay(futureDate2);
 
@@ -640,9 +644,11 @@ describe('FoodManufacturersService', () => {
     it('monthly donation recurs twice before yearly donation', async () => {
       const foodManufacturerId = 1;
       const monthlyDate = new Date();
+      monthlyDate.setMilliseconds(0);
       monthlyDate.setDate(monthlyDate.getDate() + 60);
       clampDay(monthlyDate);
       const yearlyDate = new Date();
+      yearlyDate.setMilliseconds(0);
       yearlyDate.setFullYear(yearlyDate.getFullYear() + 1);
 
       // FM 1 has donations 1 and 4
@@ -675,9 +681,11 @@ describe('FoodManufacturersService', () => {
     it('yearly donation recurs twice before every-3-years donation', async () => {
       const foodManufacturerId = 1;
       const yearlyDate = new Date();
+      yearlyDate.setMilliseconds(0);
       yearlyDate.setDate(yearlyDate.getDate() + 30);
       clampDay(yearlyDate);
       const threeYearlyDate = new Date();
+      threeYearlyDate.setMilliseconds(0);
       threeYearlyDate.setFullYear(threeYearlyDate.getFullYear() + 3);
 
       // FM 1 has donations 1 and 4
@@ -709,8 +717,10 @@ describe('FoodManufacturersService', () => {
     it('generates next weekly occurrence when a later donation would otherwise take its slot', async () => {
       const foodManufacturerId = 1;
       const weeklyDate = new Date();
+      weeklyDate.setMilliseconds(0);
       weeklyDate.setDate(weeklyDate.getDate() + 3);
       const monthlyDate = new Date();
+      monthlyDate.setMilliseconds(0);
       monthlyDate.setDate(monthlyDate.getDate() + 30);
       clampDay(monthlyDate);
 
@@ -742,12 +752,15 @@ describe('FoodManufacturersService', () => {
 
     it('only returns the next two reminders when more exist', async () => {
       const futureDate1 = new Date();
+      futureDate1.setMilliseconds(0);
       futureDate1.setDate(futureDate1.getDate() + 30);
       clampDay(futureDate1);
       const futureDate2 = new Date();
+      futureDate2.setMilliseconds(0);
       futureDate2.setDate(futureDate2.getDate() + 60);
       clampDay(futureDate2);
       const futureDate3 = new Date();
+      futureDate3.setMilliseconds(0);
       futureDate3.setDate(futureDate3.getDate() + 90);
       clampDay(futureDate3);
 
@@ -769,8 +782,10 @@ describe('FoodManufacturersService', () => {
 
     it('caps stored dates to occurrencesRemaining when more dates are stored than occurrences', async () => {
       const date1 = new Date();
+      date1.setMilliseconds(0);
       date1.setDate(date1.getDate() + 3);
       const date2 = new Date();
+      date2.setMilliseconds(0);
       date2.setDate(date2.getDate() + 4);
 
       await testDataSource.query(
@@ -792,6 +807,7 @@ describe('FoodManufacturersService', () => {
 
     it('still returns a past date (unsent reminder that will be retried)', async () => {
       const pastDate = new Date();
+      pastDate.setMilliseconds(0);
       pastDate.setDate(pastDate.getDate() - 1);
 
       await testDataSource.query(
@@ -809,8 +825,10 @@ describe('FoodManufacturersService', () => {
 
     it('past date counts against occurrencesRemaining cap, preventing the future date from showing', async () => {
       const pastDate = new Date();
+      pastDate.setMilliseconds(0);
       pastDate.setDate(pastDate.getDate() - 1);
       const futureDate = new Date();
+      futureDate.setMilliseconds(0);
       futureDate.setDate(futureDate.getDate() + 7);
 
       await testDataSource.query(
@@ -837,6 +855,7 @@ describe('FoodManufacturersService', () => {
 
     it('returns no reminders when occurrencesRemaining is 0 even if dates are stored', async () => {
       const futureDate = new Date();
+      futureDate.setMilliseconds(0);
       futureDate.setDate(futureDate.getDate() + 7);
 
       await testDataSource.query(

--- a/apps/backend/src/orders/order.service.spec.ts
+++ b/apps/backend/src/orders/order.service.spec.ts
@@ -452,7 +452,9 @@ describe('OrdersService', () => {
 
       if (!shippedOrder) throw new Error('Missing shipped order test object');
 
-      const dateReceived = new Date().toISOString();
+      const now = new Date();
+      now.setMilliseconds(0);
+      const dateReceived = now.toISOString();
       const feedback = 'Perfect delivery!';
       const photos = ['photo1.jpg', 'photo2.jpg'];
 
@@ -505,7 +507,9 @@ describe('OrdersService', () => {
       });
       await orderRepo.save(secondOrder);
 
-      const dateReceived = new Date().toISOString();
+      const now = new Date();
+      now.setMilliseconds(0);
+      const dateReceived = now.toISOString();
       const feedback = 'Perfect delivery!';
       const photos = ['photo1.jpg', 'photo2.jpg'];
 


### PR DESCRIPTION
### ℹ️ Issue

Bug: Backend tests using Date() are flakey - failed in https://github.com/Code-4-Community/ssf/pull/179 

### 📝 Description

problem: our integration tests are hitting postgres using mock data & performing real actions on that data. when we test with JavaScript’s Date() it needs to be converted it to Postgre’s timestamptz to insert into the test database & run our testing queries etc. in converting from JavaScript’s milliseconds to Postgres’s microseconds, it can lead to a millisecond being dropped. which is why it’s flaky sometimes since it is not deterministic~

fix: 
insert date.setMilliseconds(0); after every Date() declaration 

### ✔️ Verification
github workflows backend tests are green 

### 🏕️ (Optional) Future Work / Notes

Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!
